### PR TITLE
Implement gfxalloc

### DIFF
--- a/common.py
+++ b/common.py
@@ -226,6 +226,10 @@ CPP = os.path.join(DEVKITPPC, "bin", "powerpc-eabi-cpp")
 
 ICONV = f"{PYTHON} tools/sjis.py" # TODO: get actual iconv working(?)
 
+# N64 SDK path for GBI
+N64SDK = os.environ.get("N64_SDK")
+assert N64SDK != None, "N64_SDK is not defined as a system environment variable"
+
 #########
 # Files #
 #########
@@ -290,14 +294,16 @@ ASFLAGS = ' '.join([
     "-m gekko",
     f"-I {INCDIR}",
     f"-I {PPCDIS_INCDIR}",
-    f"-I orig"
+    f"-I orig",
+    f"-I {N64SDK}/ultra/usr/include"
 ])
 
 CPPFLAGS = ' '.join([
     "-nostdinc",
     f"-I {INCDIR}",
     f"-I {PPCDIS_INCDIR}",
-    f"-I {BUILD_INCDIR}"
+    f"-I {BUILD_INCDIR}",
+    f"-I {N64SDK}/ultra/usr/include"
 ])
 
 DOL_SDATA2_SIZE = 8
@@ -308,9 +314,13 @@ CFLAGS = [
     "-char unsigned",
     "-fp hard"
 ]
-CPLFLAGS =[
+CPLFLAGS = [
     "-lang=c++",
     "-O0"
+]
+REL_DEFINES = [
+    "-d _LANGUAGE_C",
+    "-d F3DEX_GBI_2"
 ]
 BASE_DOL_CFLAGS = CFLAGS + [
     "-inline on",
@@ -321,7 +331,7 @@ BASE_REL_CFLAGS = CFLAGS + [
      "-sdata 0",
      f"-sdata2 {REL_SDATA2_SIZE}",
      "-pool off"
-]
+] + REL_DEFINES
 
 LOCAL_CFLAGS = [
     "-nostdinc",
@@ -331,7 +341,8 @@ LOCAL_CFLAGS = [
     "-I-",
     f"-i {INCDIR}",
     f"-i {PPCDIS_INCDIR}",
-    f"-i {BUILD_INCDIR}"
+    f"-i {BUILD_INCDIR}",
+   f"-ir {N64SDK}/ultra/usr/include"
 ]
 
 PREPROCESSOR_CFLAGS = [

--- a/config/rel_slices.yml
+++ b/config/rel_slices.yml
@@ -7,6 +7,8 @@ m_room_type/mRmTp_FtrItemNo2FtrIdx.c:
 #   .rodata: [0x80643310, 0x80643318]
 sys_stacks.c:
     .bss: [0x812F5670, 0x812F9670]
+gfxalloc.c:
+    .text: [0x804054b0, 0x80405518]
 #zurumode/zerucheck_init.c:
 #    .text: [0x8040eb38, 0x8040EB50] 
 #zurumode/zerucheck_key_check.c:

--- a/configure.py
+++ b/configure.py
@@ -638,6 +638,7 @@ class CSource(Source):
             rule="iconv",
             inputs=self.src_path
         )
+
         #n.build(
         #    self.o_path,
         #    rule = "cc",
@@ -648,8 +649,8 @@ class CSource(Source):
         #        "cflags" : self.cflags + ' ' + c.PREPROCESS_CFLAGS
         #    }
         #)
-        #print(self.i_path)
-        
+        #return;
+    
         if self.frank == True:
             #print(f"python3 franklite.py {self.o_path} {self.o_path}")
             n.build(

--- a/include/JSystem/JKernel/JKRAram.h
+++ b/include/JSystem/JKernel/JKRAram.h
@@ -9,9 +9,6 @@
 #include "JSystem/JKernel/JKRThread.h"
 #include "JSystem/JSupport/JSUList.h"
 
-#define ALIGN_PREV(u, align) (u & (~(align-1)))
-#define ALIGN_NEXT(u, align) ((u + (align-1)) & (~(align-1)))
-
 #define ARAM_GROUP_ID_ALL 0
 #define ARAM_GROUP_ID_DEFAULT 0xFF
 

--- a/include/gfxalloc.h
+++ b/include/gfxalloc.h
@@ -1,0 +1,19 @@
+#ifndef GFXALLOC_H
+#define GFXALLOC_H
+
+#include "types.h"
+#include "PR/mbi.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+extern Gfx* gfxopen(Gfx* gfxp);
+extern Gfx* gfxclose(Gfx* gfxp, Gfx* gfxp_new);
+extern Gfx* gfxalloc(Gfx** gfxpp, size_t size);
+
+#ifdef __cplusplus
+};
+#endif
+
+#endif

--- a/include/types.h
+++ b/include/types.h
@@ -40,6 +40,9 @@ typedef u32 unknown;
 
 #define AT_ADDRESS(x) : (x)
 
+#define ALIGN_PREV(u, align) (u & (~(align-1)))
+#define ALIGN_NEXT(u, align) ((u + (align-1)) & (~(align-1)))
+
 #ifndef ATTRIBUTE_ALIGN
 #if defined(__MWERKS__) || defined(__GNUC__)
 #define ATTRIBUTE_ALIGN(num) __attribute__((aligned(num)))

--- a/rel/gfxalloc.c
+++ b/rel/gfxalloc.c
@@ -1,0 +1,29 @@
+#include "gfxalloc.h"
+#include "types.h"
+
+extern Gfx* gfxopen(Gfx* gfxpp) {
+  return gfxpp + 1;
+}
+
+extern Gfx* gfxclose(Gfx* gfxp, Gfx* gfxp_new) {
+  if (gfxp + 1 != gfxp_new) {
+    gSPBranchList(gfxp, gfxp_new);
+    return gfxp_new;
+  }
+
+  gSPNoOp(gfxp);
+  return gfxp;
+}
+
+extern Gfx* gfxalloc(Gfx** gfxpp, size_t size) {
+  u8* ptr;
+  Gfx* dst;
+
+  size = ALIGN_NEXT(size, 8);
+  ptr = (u8*)(*gfxpp + 1);
+  dst = (Gfx*)(ptr + size);
+  gSPBranchList(*gfxpp, dst);
+
+  *gfxpp = dst;
+  return (Gfx*)ptr;
+}


### PR DESCRIPTION
This PR implements `rel/gfxalloc.c`. As this uses N64's `Gfx` union, the N64 SDK or equivalent is now required for building. Users must source that on their own for now. `N64_SDK` environment variable must point to the SDK's base path such that `$N64_SDK/ultra/usr/include` exists.