### PR TITLE
Implement THA and THA_GA

### DIFF
--- a/config/dol_slices.yml
+++ b/config/dol_slices.yml
@@ -53,9 +53,9 @@ libc64/qrand.c:
 #libc64/malloc.c:
 #    .text: [0x8005cf08, 0x8005d01c]
 #    .bss: [0x80206F30, 0x80206F60]
-#libultra/ultra.c:                  won't link
-#    .text: [0x8005d01c, 0x8005d15c]
-#    .bss: [0x80206f60, 0x80206fa0]
+libultra/ultra.c:
+    .text: [0x8005d01c, 0x8005d15c]
+    .bss: [0x80206f60, 0x80206fa0]
 #libultra/gu/scale.c:
 #    .text: [0x8005e7d4, 0x8005e860]
 #    .sdata2: [0x80219208, 0x80219210]

--- a/config/rel_slices.yml
+++ b/config/rel_slices.yml
@@ -7,6 +7,10 @@ m_room_type/mRmTp_FtrItemNo2FtrIdx.c:
 #   .rodata: [0x80643310, 0x80643318]
 sys_stacks.c:
     .bss: [0x812F5670, 0x812F9670]
+THA_GA.c:
+    .text: [0x80404AE0, 0x80404B40]
+TwoHeadArena.c:
+    .text: [0x80404B40, 0x80404C68]
 gfxalloc.c:
     .text: [0x804054b0, 0x80405518]
 #zurumode/zerucheck_init.c:

--- a/include/THA_GA.h
+++ b/include/THA_GA.h
@@ -1,0 +1,49 @@
+#ifndef THA_GA_H
+#define THA_GA_H
+
+#include "TwoHeadArena.h"
+#include "PR/mbi.h"
+#include "types.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct {
+  size_t size;
+  Gfx* buf_p;
+  Gfx* head_p;
+  Gfx* tail_p;
+} TwoHeadArenaGfx_t;
+
+typedef TwoHeadArenaGfx_t TwoHeadArenaGfx;
+
+typedef union {
+  TwoHeadArena tha;
+  TwoHeadArenaGfx thaGfx;
+} THA_GA_t;
+
+typedef THA_GA_t THA_GA;
+
+extern void THA_GA_ct(THA_GA* this, Gfx* p, size_t n);
+extern void THA_GA_dt(THA_GA* this); /* @unused */
+extern int THA_GA_isCrash(THA_GA* this);
+extern void THA_GA_init(THA_GA* this); /* @unused*/
+extern int THA_GA_getFreeBytes(THA_GA* this);
+extern void* THA_GA_getTailPtr(THA_GA* this); /* @unused */
+extern void* THA_GA_nextPtrN(THA_GA* this, size_t n); /* @unused */
+extern void* THA_GA_nextPtr1(THA_GA* this); /* @unused */
+extern Gfx* THA_GA_NEXT_DISP(THA_GA* this); /* @unused */
+extern void* THA_GA_getHeadPtr(THA_GA* this); /* @unused */
+extern void THA_GA_setHeadPtr(THA_GA* this, void *p); /* @unused */
+extern Mtx* THA_GA_alloc(THA_GA* this, size_t n); /* @unused */
+extern Mtx* THA_GA_allocMtxN(THA_GA* this, size_t n); /* @unused */
+extern Mtx* THA_GA_allocMtx1(THA_GA* this); /* @unused */
+extern Vtx* THA_GA_allocVtxN(THA_GA* this, size_t n); /* @unused */
+extern Vtx* THA_GA_allocVtx1(THA_GA* this); /* @unused */
+
+#ifdef __cplusplus
+};
+#endif
+
+#endif

--- a/include/TwoHeadArena.h
+++ b/include/TwoHeadArena.h
@@ -1,0 +1,39 @@
+#ifndef TWOHEADARENA_H
+#define TWOHEADARENA_H
+
+#include "types.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct {
+  size_t size;
+  char *buf_p;
+  char *head_p;
+  char *tail_p;
+} TwoHeadArena_t;
+typedef TwoHeadArena_t TwoHeadArena;
+typedef TwoHeadArena_t THA;
+
+extern void THA_ct(TwoHeadArena* this, char* p, size_t n);
+extern void THA_dt(TwoHeadArena* this);
+extern void* THA_getHeadPtr(TwoHeadArena* this); /* @unused */
+extern void THA_setHeadPtr(TwoHeadArena* this, void* p); /* @unused */
+extern void* THA_getTailPtr(TwoHeadArena* this); /* @unused */
+extern void* THA_nextPtrN(TwoHeadArena* this, size_t n); /* @unused */
+extern void* THA_nextPtr1(TwoHeadArena* this); /* @unused */
+extern void* THA_alloc(TwoHeadArena* this, size_t siz);
+extern void* THA_alloc16(TwoHeadArena* this, size_t siz);
+extern void* THA_allocAlign(TwoHeadArena* this, size_t siz, int mask);
+extern int THA_isCrash(TwoHeadArena* this);
+extern void THA_init(TwoHeadArena* this);
+extern int THA_getFreeBytes16(TwoHeadArena* this);
+extern int THA_getFreeBytes(TwoHeadArena* this);
+extern int THA_getFreeBytesAlign(TwoHeadArena* this, int mask);
+
+#ifdef __cplusplus
+};
+#endif
+
+#endif

--- a/include/libultra/libultra.h
+++ b/include/libultra/libultra.h
@@ -13,6 +13,6 @@ void osWritebackDCache(void* vaddr, u32 nbytes);
 u32 osGetCount(void);
 OSTime osGetTime(void);
 
-static s32 osAppNMIBuffer[15]; 
+extern s32 osAppNMIBuffer[]; 
 
 #endif

--- a/rel/THA_GA.c
+++ b/rel/THA_GA.c
@@ -1,0 +1,16 @@
+#include "THA_GA.h"
+#include "types.h"
+
+/* TODO: fabricate unused methods */
+
+extern void THA_GA_ct(THA_GA* this, Gfx* p, size_t n) {
+  THA_ct(&this->tha, (char*)p, n);
+}
+
+extern int THA_GA_isCrash(THA_GA* this) {
+  return THA_isCrash(&this->tha);
+}
+
+extern int THA_GA_getFreeBytes(THA_GA* this) {
+  return THA_getFreeBytes(&this->tha);
+}

--- a/rel/TwoHeadArena.c
+++ b/rel/TwoHeadArena.c
@@ -1,0 +1,102 @@
+#include "TwoHeadArena.h"
+
+#include "libultra/libultra.h"
+#include "types.h"
+
+/* @fabricated */
+/*
+extern void* THA_getHeadPtr(TwoHeadArena* this) {
+  return this->head_p;
+}
+*/
+
+/* @fabricated */
+/*
+extern void THA_setHeadPtr(TwoHeadArena* this, void* p) {
+  this->head_p = (char*)p;
+}
+*/
+
+/* @fabricated */
+/*
+extern void* THA_getTailPtr(TwoHeadArena* this) {
+  return this->tail_p;
+}
+*/
+
+/* @fabricated */
+/*
+extern void* THA_nextPtrN(TwoHeadArena* this, size_t n) {
+  char* next_p = this->head_p;
+  this->head_p += n;
+  return (void*)next_p;
+}
+*/
+
+/* @fabricated */
+/*
+extern void* THA_nextPtr1(TwoHeadArena* this) {
+  return THA_nextPtrN(this, 1);
+}
+*/
+
+/* @fabricated */
+/*
+extern void* THA_alloc(TwoHeadArena* this, size_t siz) {
+  u32 mask;
+  if (siz == 8) {
+    mask = ~(8 - 1);
+  } else if (siz == 2 || siz == 6 || siz == 10 || siz == 14) {
+    mask = ~(2 - 1);
+  } else if (siz > 15) {
+    mask = ~(16 - 1);
+  } else {
+    mask = ~0;
+  }
+
+  this->tail_p = (char*)((((u32)this->tail_p & mask) - siz) & mask);
+  return this->tail_p;
+}
+*/
+
+extern void* THA_alloc16(TwoHeadArena* this, size_t siz) {
+  const int mask = ~(16 - 1);
+  this->tail_p = (char*)((((u32)this->tail_p & mask) - siz) & mask);
+  return this->tail_p;
+}
+
+extern void* THA_allocAlign(TwoHeadArena* this, size_t siz, int mask) {
+  this->tail_p = (char*)((((u32)this->tail_p & mask) - siz) & mask);
+  return this->tail_p;
+}
+
+extern int THA_getFreeBytesAlign(TwoHeadArena* this, int mask) {
+  return (int)this->tail_p - (mask & (int)(this->head_p + ~mask));
+}
+
+extern int THA_getFreeBytes16(TwoHeadArena* this) {
+  return THA_getFreeBytesAlign(this, -16);
+}
+
+extern int THA_getFreeBytes(TwoHeadArena* this) {
+  return THA_getFreeBytesAlign(this, -1);
+}
+
+extern int THA_isCrash(TwoHeadArena* this) {
+  return THA_getFreeBytes(this) < 0;
+}
+
+extern void THA_init(TwoHeadArena* this) {
+  this->head_p = this->buf_p;
+  this->tail_p = this->buf_p + this->size;
+}
+
+extern void THA_ct(TwoHeadArena* this, char* p, size_t n) {
+  this->buf_p = p;
+  this->size = n;
+  THA_init(this);
+}
+
+extern void THA_dt(TwoHeadArena* this) {
+  bzero(this, sizeof(TwoHeadArena));
+}

--- a/src/libultra/ultra.c
+++ b/src/libultra/ultra.c
@@ -4,11 +4,11 @@
 #include "dolphin/os/OSTime.h"
 
 extern OSTime __osTimeOffset;
+s32 osAppNMIBuffer[16];
 
 void bcopy(void* __src, void* __dst, size_t __n) {
     memmove(__dst, __src, __n);
 }
-
 
 int bcmp(void* __s1, void* __s2, size_t __n) {
     return memcmp(__s1, __s2, __n);
@@ -17,18 +17,19 @@ int bcmp(void* __s1, void* __s2, size_t __n) {
 void bzero(void* __s, size_t __n) {
     memset(__s, 0, __n);
 }
-void osSyncPrintf(const char* format, ...){
+
+void osSyncPrintf(const char* format, ...) {
     va_list arg;
     va_start(arg, format);
     OSVReport(format, arg);
     va_end(arg);
 
 }
-void osWritebackDCache(void* buf, u32 len){
+void osWritebackDCache(void* buf, u32 len) {
 	 DCStoreRange(buf, len);
 }
 
-u32 osGetCount(void){
+u32 osGetCount(void) {
 	return OSGetTick();
 }
 


### PR DESCRIPTION
Both `rel/TwoHeadArena.c` and `rel/THA_GA.c` have been implemented. Some functions were commented out as they were fabricated, and were added to the relocatable module despite being unused. `THA_GA` still has some fabricated unused functions to implement.

Also fixed `libultra/osAppNMIBuffer` and got `ultra.c` linking.