### PR TITLE
Add patched MWCC 1.3.2r, implement & link m_bank_ovl.c

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -16,8 +16,10 @@ Use `--recursive` when cloning to have ppcdis in the repository.
 - Decompress **foresta.rel.szs** with yaz0 found in *tools/*.
 - Place **main.dol** and **foresta.rel** in *dump/*.
 - Place CodeWarrior 1.3.2 in *tools/1.3.2/* and 1.2.5n in *tools/1.2.5n/*.
+- Download [CodeWarrior 1.3.2r](https://cdn.discordapp.com/attachments/598600200084258822/1136883349642825728/MWCCEPPC_1.3.2r.zip) and extract it to *tools/1.3.2r/*.
 - Set the `N64_SDK` environmental variables with the path of your libultra or equivalent headers.
 	- Headers should be at `$N64_SDK/ultra/usr/include`.
+    - You may need to modify `Gpopmtx`'s `param` member to be `unsigned int`.
 - Install DevkitPPC, Ninja and Python:
     - **Only tested with DevkitPPC r41 and Python 3.8.10**, however other versions should work fine.
 - Install Python modules from requirements.txt (`pip install -r requirements.txt`)

--- a/common.py
+++ b/common.py
@@ -202,12 +202,15 @@ FORCEFILESGEN = f"{PYTHON} {PPCDIS}/forcefilesgen.py"
 # Codewarrior
 TOOLS = "tools"
 CODEWARRIOR = os.path.join(TOOLS, "1.3.2")
+CODEWARRIOR_RODATA_POOL_FIX = os.path.join(TOOLS, "1.3.2r")
 SDK_CW = os.path.join(TOOLS, "1.2.5n")
 CC = os.path.join(CODEWARRIOR, "mwcceppc.exe")
+CC_R = os.path.join(CODEWARRIOR_RODATA_POOL_FIX, "mwcceppc.exe")
 OCC = os.path.join(SDK_CW, "mwcceppc.exe")
 LD = os.path.join(CODEWARRIOR, "mwldeppc.exe")
 if platform != "win32":
     CC = f"wibo {CC}"
+    CC_R = f"wibo {CC_R}"
     OCC = f"wibo {OCC}"
     LD = f"wibo {LD}"
 
@@ -323,7 +326,8 @@ COMMON_DEFINES = [
 ]
 DOL_DEFINES = COMMON_DEFINES + []
 REL_DEFINES = COMMON_DEFINES + [ 
-    "-d OPTIMIZED_SQRTF"
+    "-d OPTIMIZED_SQRTF",
+    "-d IS_REL"
 ]
 BASE_DOL_CFLAGS = CFLAGS + [
     "-inline on",
@@ -359,7 +363,7 @@ TRK_CFLAGS = [
 BASE_REL_CFLAGS = CFLAGS + [
      "-sdata 0",
      f"-sdata2 {REL_SDATA2_SIZE}",
-     "-pool off",
+     #"-pool off",
      "-sym on"
 ] + REL_DEFINES
 

--- a/config/rel_slices.yml
+++ b/config/rel_slices.yml
@@ -151,11 +151,11 @@ m_start_data_init.c:
 m_string.c:
     .text: [0x803EED30, 0x803EF290]
     .bss: [0x8129F320, 0x8129F400]
-#m_time.c: # unlinked until function callers that reorder local static variables are implemented.
-#    .text: [0x803F33DC, 0x803F3E58]
-#    .rodata: [0x806433B0, 0x806433D8]
-#    .data: [0x8065E378, 0x8065E438]
-#    .bss: [0x8129F410, 0x8129F420]
+m_time.c:
+    .text: [0x803F33DC, 0x803F3E58]
+    .rodata: [0x806433B0, 0x806433D8]
+    .data: [0x8065E378, 0x8065E438]
+    .bss: [0x8129F410, 0x8129F420]
 m_skin_matrix.c:
     .text: [0x803f1528, 0x803f1bb4]
     .rodata: [0x80643310, 0x80643318]
@@ -290,6 +290,11 @@ ac_train1.c:
     .text: [0x805C0614, 0x805C0CC8]
     .rodata: [0x8064AD80, 0x8064ADB0]
     .data: [0x806C7300, 0x806C7388]
+m_bank_ovl.c:
+    .text: [0x805C38E4, 0x805C4714]
+    .rodata: [0x8064AE58, 0x8064AE90]
+    .data: [0x806C7B90, 0x806C7BE0]
+    .bss: [0x8133E0A8, 0x8133E0C0]
 m_select.c:
     .text: [0x80627F88, 0x80629CA8]
     .rodata: [0x8064D1B0, 0x8064D1B8]

--- a/configure.py
+++ b/configure.py
@@ -81,7 +81,7 @@ n.variable("forceactivegen", c.FORCEACTIVEGEN)
 n.variable("elf2dol", c.ELF2DOL)
 n.variable("elf2rel", c.ELF2REL)
 n.variable("codewarrior", c.CODEWARRIOR)
-n.variable("cc", c.CC)
+n.variable("cc", c.CC_R)
 n.variable("occ", c.OCC)
 n.variable("align16", c.ALIGN16)
 n.variable("ld", c.LD)
@@ -626,7 +626,7 @@ class CSource(Source):
             self.cflags = c.DOL_TRK_CFLAGS
         else:
             self.cflags = ctx.cflags
-            self.cc = c.CC
+            self.cc = c.CC_R
         self.iconv_path = f"$builddir/iconv/{path}"
 
  # Find generated includes
@@ -634,7 +634,7 @@ class CSource(Source):
             gen_includes = GeneratedInclude.find(ctx, path, f.read())
 
         self.s_path = f"$builddir/{path}.s"
-        super().__init__(True, path, f"$builddir/{path}.o", gen_includes)
+        super().__init__(True, path, f"$builddir/{os.path.splitext(path)[0]}.o", gen_includes)
         
     def build(self):
         n.build(

--- a/include/audio_defs.h
+++ b/include/audio_defs.h
@@ -10,6 +10,8 @@ extern "C" {
 /* audio is monophonic */
 #define MONO(id) (id | 0x1000)
 
+#define SE_CURSOR_MOVE 0x01
+#define SE_MENU_EXIT 0x02
 #define SE_COIN 0x4C
 #define SE_REGISTER MONO(0x50)
 

--- a/include/lb_rtc.h
+++ b/include/lb_rtc.h
@@ -112,7 +112,7 @@ extern int lbRTC_IsOverTime(const lbRTC_time_c* t0, const lbRTC_time_c* t1);
 extern int lbRTC_IsOverRTC(const lbRTC_time_c* time);
 extern int lbRTC_IntervalTime(const lbRTC_time_c* time0, const lbRTC_time_c* time1);
 extern int lbRTC_GetIntervalDays(const lbRTC_time_c* t0, const lbRTC_time_c* t1);
-extern int lbRTC_GetIntervalDays2(const lbRTC_ymd_t* ymd0, const lbRTC_ymd_t* ymd1);
+extern int lbRTC_GetIntervalDays2(lbRTC_ymd_t* ymd0, lbRTC_ymd_t* ymd1);
 extern void lbRTC_Add_YY(lbRTC_time_c* time, int year);
 extern void lbRTC_Add_MM(lbRTC_time_c* time, int month);
 extern void lbRTC_Add_DD(lbRTC_time_c* time, int day);

--- a/include/m_bank_ovl.h
+++ b/include/m_bank_ovl.h
@@ -1,0 +1,33 @@
+#ifndef M_BANK_OVL_H
+#define M_BANK_OVL_H
+
+#include "types.h"
+#include "m_bank_ovl_h.h"
+#include "m_submenu_ovl.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define mBN_CURSOL_MAX 5
+#define mBN_CUSROL_OK 6
+#define mBN_DEPOSIT_MAX 999999999
+
+struct bank_ovl_s {
+  int player_max_bell; /* maximum amount of bells the player can hold */
+  int player_bell; /* bells the player started with when opening the bank window */
+  int now_bell; /* current bells the player has */
+  int bank_bell; /* current bells the bank has */
+  int cursol; /* cursor position */
+  int bell; /* change in bells */
+};
+
+extern void mBN_bank_ovl_set_proc(Submenu* submenu);
+extern void mBN_bank_ovl_construct(Submenu* submenu);
+extern void mBN_bank_ovl_destruct(Submenu* submenu);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/include/m_bank_ovl_h.h
+++ b/include/m_bank_ovl_h.h
@@ -1,0 +1,16 @@
+#ifndef M_BANK_OVL_H_H
+#define M_BANK_OVL_H_H
+
+#include "types.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct bank_ovl_s mBN_Overlay_c;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/include/m_submenu_ovl.h
+++ b/include/m_submenu_ovl.h
@@ -7,7 +7,9 @@
 #include "graph.h"
 #include "m_mail.h"
 #include "PR/mbi.h"
+#include "PreRender.h"
 #include "m_map_ovl_h.h"
+#include "m_bank_ovl_h.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -75,6 +77,8 @@ typedef void (*mSM_DRAW_MAIL_PROC)(GRAPH*, f32, f32, f32, Mail_c*, int, int);
 typedef void (*mSM_SETUP_VIEW_PROC)(Submenu*, GRAPH*, int);
 typedef void (*mSM_CHANGE_VIEW_PROC)(GRAPH*, f32, f32, f32, s16, int, int);
 
+typedef void (*mSM_MOVE_PROC)(Submenu*, mSM_MenuInfo_c*);
+
 /* sizeof(struct submenu_overlay_s) == 0xA04 */
 struct submenu_overlay_s {
   /* TODO: finish */
@@ -95,7 +99,9 @@ struct submenu_overlay_s {
   /* 0x96C */ mSM_CHANGE_VIEW_PROC change_view_proc;
   /* 0x970 */ u8 _940[0x9B4 - 0x970];
   /* 0x9B4 */ mMP_Overlay_c* map_ovl;
-  /* 0x9B8 */ u8 _9B8[0xA00 - 0x9B8];
+  /* 0x9B8 */ u8 _9B8[0x9D4 - 0x9B8];
+  /* 0x9D4 */ mBN_Overlay_c* bank_ovl;
+  /* 0x9D8 */ u8 _9D8[0xA00 - 0x9D8];
   /* 0xA00 */ Mtx* projection_matrix;
 };
 

--- a/include/m_time.h
+++ b/include/m_time.h
@@ -77,7 +77,7 @@ extern int mTM_check_renew_time(u8 renew_flag);
 extern void mTM_off_renew_time(u8 renew_flag);
 extern void mTM_set_renew_is();
 extern void mTM_set_renew_time(lbRTC_ymd_t* renew_time, const lbRTC_time_c* time);
-extern void mTM_ymd_2_time(lbRTC_time_c* time, const lbRTC_ymd_t* ymd);
+extern void mTM_ymd_2_time(lbRTC_time_c* time, lbRTC_ymd_t* ymd);
 extern void mTM_renewal_renew_time();
 extern void mTM_clear_renew_is();
 extern void mTM_rtcTime_limit_check();

--- a/include/types.h
+++ b/include/types.h
@@ -1,6 +1,12 @@
 #ifndef TYPES_H
 #define TYPES_H
 
+#include "../tools/ppcdis/include/ppcdis.h"
+
+#ifdef IS_REL
+//#pragma section const_type sconst_type ".rodata" ".rodata" data_mode=far_abs code_mode=pc_rel
+#endif
+
 typedef signed char s8;
 typedef signed short s16;
 typedef signed long s32;
@@ -71,6 +77,16 @@ typedef u32 unknown;
     #define FORCESTRIP __declspec(section "forcestrip")
 #else
     #define FORCESTRIP
+#endif
+
+#if !defined(__INTELLISENSE__) && defined(MUST_MATCH)
+    #define BSS_ORDER_GROUP_START FORCESTRIP ORDER_BSS_DATA {
+    #define BSS_ORDER_GROUP_END }
+    #define BSS_ORDER_ITEM(v) ORDER_BSS(v)
+#else
+    #define BSS_ORDER_GROUP_START
+    #define BSS_ORDER_GROUP_END
+    #define BSS_ORDER_ITEM(v)
 #endif
 
 #endif

--- a/rel/lb_rtc.c
+++ b/rel/lb_rtc.c
@@ -618,7 +618,7 @@ extern int lbRTC_GetIntervalDays(const lbRTC_time_c* t0, const lbRTC_time_c* t1)
  * @param ymd1 Pointer to the second lbRTC_ymd_t structure.
  * @return Number of days between the two given dates, negative if ymd0 is greater than ymd1.
  */
-extern int lbRTC_GetIntervalDays2(const lbRTC_ymd_t* ymd0, const lbRTC_ymd_t* ymd1) {
+extern int lbRTC_GetIntervalDays2(lbRTC_ymd_t* ymd0, lbRTC_ymd_t* ymd1) {
   lbRTC_time_c t0, t1;
   int equality;
 

--- a/rel/m_bank_ovl.c
+++ b/rel/m_bank_ovl.c
@@ -1,0 +1,450 @@
+#include "m_bank_ovl.h"
+
+#include "m_name_table.h"
+#include "audio.h"
+#include "sys_matrix.h"
+#include "m_font.h"
+#include "m_lib.h"
+#include "m_common_data.h"
+
+static int aNSM_sack_amount[MONEY_NUM] = {
+  100,
+  1000,
+  10000,
+  30000
+};
+
+static mActor_name_t aNSM_itemNo[MONEY_NUM] = {
+  ITM_MONEY_100,
+  ITM_MONEY_1000,
+  ITM_MONEY_10000,
+  ITM_MONEY_30000
+};
+
+static void mBN_now_bell_2_bell(mBN_Overlay_c* bank_ovl) {
+  int diff = bank_ovl->now_bell - bank_ovl->player_bell;
+  bank_ovl->bell = ABS(diff);
+}
+
+static int mBN_cursol_2_keta(int cursol) {
+  int keta = 1;
+  int i;
+
+  for (i = cursol; i < mBN_CURSOL_MAX; i++) {
+    keta *= 10;
+  }
+
+  return keta;
+}
+
+static int mBN_total_item_bell() {
+  int i;
+  int total_item_bell = 0;
+
+  for (i = 0; i < MONEY_NUM; i++) {
+    int possess = mPr_GetPossessionItemSumWithCond(Common_Get(now_private), aNSM_itemNo[i], mPr_ITEM_COND_NORMAL);
+
+    total_item_bell += possess * aNSM_sack_amount[i];
+  }
+
+  return total_item_bell;
+}
+
+static void mBN_bank_ok(Submenu* submenu, mSM_MenuInfo_c* menu, mBN_Overlay_c* bank_ovl) {
+  if (bank_ovl->bank_bell < 0) {
+    bank_ovl->bank_bell = 0;
+  }
+
+  if (bank_ovl->bank_bell > mBN_DEPOSIT_MAX) {
+    bank_ovl->bank_bell = mBN_DEPOSIT_MAX;
+  }
+
+  Common_Get(now_private)->bank_account = bank_ovl->bank_bell;
+
+  {
+    int total_item_bell = mBN_total_item_bell();
+    int i = 0;
+
+    /* Replace all money sack items with EMPTY_NO */
+    while (bank_ovl->now_bell < total_item_bell && i < MONEY_NUM) {
+      int sack_idx = mPr_GetPossessionItemIdxWithCond(Common_Get(now_private), aNSM_itemNo[i], mPr_ITEM_COND_NORMAL);
+      if (sack_idx == -1) {
+        i++; /* move onto next sack amount */
+      }
+      else {
+        mPr_SetPossessionItem(Common_Get(now_private), sack_idx, EMPTY_NO, mPr_ITEM_COND_NORMAL);
+      }
+
+      total_item_bell = mBN_total_item_bell(); /* update total bell count in sacks */
+    }
+  }
+
+  {
+    /* Replace non-30k bell bags with 30k bell bags */
+    int i;
+    int total_item_bell = bank_ovl->now_bell - mBN_total_item_bell();
+    
+    i = 0;
+      
+    while (total_item_bell > mPr_WALLET_MAX && i < MONEY_NUM - 1) {
+      int sack_idx = mPr_GetPossessionItemIdxWithCond(Common_Get(now_private), aNSM_itemNo[i], mPr_ITEM_COND_NORMAL);
+
+      if (sack_idx == -1) {
+        i++;
+      }
+      else {
+        mPr_SetPossessionItem(Common_Get(now_private), sack_idx, ITM_MONEY_30000, mPr_ITEM_COND_NORMAL);
+        total_item_bell -= 30000 - aNSM_sack_amount[i];
+      }
+    }
+
+    /* Add 30k bell bags to the inventory where empty spaces are */
+    i = 0;
+
+    while (total_item_bell > mPr_WALLET_MAX && i < 1) {
+      int sack_idx = mPr_GetPossessionItemIdxWithCond(Common_Get(now_private), EMPTY_NO, mPr_ITEM_COND_NORMAL);
+
+      if (sack_idx == -1) {
+        i++;
+      }
+      else {
+        mPr_SetPossessionItem(Common_Get(now_private), sack_idx, ITM_MONEY_30000, mPr_ITEM_COND_NORMAL);
+        total_item_bell -= 30000;
+      }
+    }
+
+    bank_ovl->now_bell -= mBN_total_item_bell();
+
+    if (bank_ovl->now_bell < 0) {
+      bank_ovl->now_bell = 0;
+    }
+    else if (bank_ovl->now_bell > mPr_WALLET_MAX) {
+      bank_ovl->now_bell = mPr_WALLET_MAX;
+    }
+
+    Common_Get(now_private)->inventory.wallet = bank_ovl->now_bell;
+    (*submenu->overlay->move_chg_base_proc)(menu, 4);
+    sAdo_SysTrgStart(SE_MENU_EXIT);
+  }
+}
+
+static void mBN_move_Move(Submenu* submenu, mSM_MenuInfo_c* menu) {
+  (*submenu->overlay->move_Move_proc)(submenu, menu);
+}
+
+static void mBN_move_Play(Submenu* submenu, mSM_MenuInfo_c* menu) {
+  Submenu_Overlay_c* overlay = submenu->overlay;
+  int trigger = overlay->menu_control.trigger;
+  mBN_Overlay_c* bank_ovl = overlay->bank_ovl;
+
+  if (trigger & BUTTON_B) {
+    (*overlay->move_chg_base_proc)(menu, 4);
+    sAdo_SysTrgStart(SE_MENU_EXIT);
+  }
+  else if (trigger & BUTTON_START) {
+    mBN_bank_ok(submenu, menu, bank_ovl);
+  }
+  else {
+    int cursol = bank_ovl->cursol;
+
+    if (cursol == mBN_CUSROL_OK) {
+      if (trigger & BUTTON_A) {
+        mBN_bank_ok(submenu, menu, bank_ovl);
+      }
+      else if (trigger & (BUTTON_CLEFT | BUTTON_CUP)) {
+        bank_ovl->cursol = cursol - 1;
+        sAdo_SysTrgStart(SE_CURSOR_MOVE);
+      }
+    }
+    else if ((trigger & BUTTON_CLEFT) && cursol > 0) {
+      bank_ovl->cursol = cursol - 1;
+      sAdo_SysTrgStart(SE_CURSOR_MOVE);
+    }
+    else if (trigger & BUTTON_CRIGHT) {
+      bank_ovl->cursol += 1;
+      sAdo_SysTrgStart(SE_CURSOR_MOVE);
+    }
+    else if ((trigger & BUTTON_CDOWN) || (trigger & BUTTON_CUP)) {
+      int keta = mBN_cursol_2_keta(cursol);
+
+      if (trigger & BUTTON_CUP) {
+        if (bank_ovl->now_bell < keta) {
+          keta = bank_ovl->now_bell;
+        }
+
+        if (keta + bank_ovl->bank_bell > mBN_DEPOSIT_MAX) {
+          keta = mBN_DEPOSIT_MAX - bank_ovl->bank_bell;
+        }
+
+        if (keta == 0) {
+          sAdo_SysTrgStart(MONO(3));
+          return;
+        }
+
+        if (bank_ovl->now_bell > bank_ovl->player_bell && (bank_ovl->now_bell - keta) < bank_ovl->player_bell) {
+          keta = bank_ovl->now_bell - bank_ovl->player_bell;
+        }
+
+        bank_ovl->bank_bell += keta;
+        bank_ovl->now_bell -= keta;
+      }
+      else {
+        if (bank_ovl->bank_bell < keta) {
+          keta = bank_ovl->bank_bell;
+        }
+        
+        if ((bank_ovl->now_bell + keta) > bank_ovl->player_max_bell) {
+          keta = bank_ovl->player_max_bell - bank_ovl->now_bell;
+        }
+
+        if (keta == 0) {
+          sAdo_SysTrgStart(MONO(3));
+          return;
+        }
+
+        if (bank_ovl->now_bell < bank_ovl->player_bell && (bank_ovl->now_bell + keta) > bank_ovl->player_bell) {
+          keta = bank_ovl->player_bell - bank_ovl->now_bell;
+        }
+
+        bank_ovl->bank_bell -= keta;
+        bank_ovl->now_bell += keta;
+      }
+
+      mBN_now_bell_2_bell(bank_ovl);
+      sAdo_SysTrgStart(0x426);
+    }
+  }
+}
+
+static void mBN_move_End(Submenu* submenu, mSM_MenuInfo_c* menu) {
+  (*submenu->overlay->move_End_proc)(submenu, menu);
+}
+
+static void mBN_bank_ovl_move(Submenu* submenu) {
+  static mSM_MOVE_PROC ovl_move_proc[5] = {
+    &mBN_move_Move,
+    &mBN_move_Play,
+    (mSM_MOVE_PROC)&none_proc1,
+    (mSM_MOVE_PROC)&none_proc1,
+    &mBN_move_End
+  };
+
+  Submenu_Overlay_c* overlay = submenu->overlay;
+  mSM_MenuInfo_c* menu = &overlay->menu_info[mSM_OVL_BANK];
+
+  (*menu->pre_move_func)(submenu);
+  (*ovl_move_proc[menu->proc_status])(submenu, menu);
+}
+
+extern Gfx tyo_win_mode[];
+extern Gfx tyo_win_model[];
+extern Gfx tyo_win_moji2T_model[];
+extern Gfx tyo_win_moji3T_model[];
+
+static void mBN_set_frame_dl(Submenu* submenu, GAME* game, mSM_MenuInfo_c* menu) {
+  GRAPH* g = game->graph;
+  mBN_Overlay_c* bank_ovl = submenu->overlay->bank_ovl;
+  Gfx* gfx;
+  u8 s;
+  u8 t;
+
+  Matrix_translate(menu->position[0] * 16.0f, menu->position[1] * 16.0f, 140.0f, 0);
+  Matrix_scale(16.0f, 16.0f, 1.0f, 1);
+
+  OPEN_DISP(g);
+  gfx = NOW_POLY_OPA_DISP;
+
+
+  gSPDisplayList(gfx++, tyo_win_mode);
+  gSPMatrix(gfx++, _Matrix_to_Mtx_new(g), G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
+  s = -submenu->overlay->menu_control.texture_pos[0] * 4.0f;
+  t = -submenu->overlay->menu_control.texture_pos[1] * 4.0f;
+  gDPSetTileSize_Dolphin(gfx++, 0, s, t, 32, 32);
+  gSPDisplayList(gfx++, tyo_win_model);
+
+  if (bank_ovl->now_bell <= bank_ovl->player_bell) {
+    gDPSetPrimColor(gfx++, 0, 255, 165, 50, 50, 255);
+    gDPSetEnvColor(gfx++, 255, 255, 255, 255);
+  }
+  else {
+    gDPSetPrimColor(gfx++, 0, 255, 100, 80, 80, 255);
+    gDPSetEnvColor(gfx++, 165, 155, 155, 255);
+  }
+
+  gSPDisplayList(gfx++, tyo_win_moji2T_model);
+  
+  if (bank_ovl->now_bell >= bank_ovl->player_bell) {
+    gDPSetPrimColor(gfx++, 0, 255, 20, 205, 20, 255);
+    gDPSetEnvColor(gfx++, 255, 255, 255, 255);
+  }
+  else {
+    gDPSetPrimColor(gfx++, 0, 255, 70, 95, 70, 255);
+    gDPSetEnvColor(gfx++, 155, 165, 155, 255);
+  }
+
+  gSPDisplayList(gfx++, tyo_win_moji3T_model);
+
+
+  SET_POLY_OPA_DISP(gfx);
+  CLOSE_DISP(g);
+}
+
+static void mBN_set_num_str(f32 x, f32 y, GAME* game, u32 num, f32 scale, rgba_t* color) {
+  u8 str[11];
+  f32 width;
+
+  mFont_UnintToString(str, 11, num, 9, FALSE, FALSE, TRUE);
+  width = mFont_GetStringWidth(str, 11, TRUE);
+  x -= scale * width;
+
+  mFont_SetLineStrings(
+    game,
+    str, 11,
+    x, y,
+    color->r, color->g, color->b, 255,
+    FALSE, TRUE,
+    scale, scale,
+    mFont_MODE_POLY
+  );
+}
+
+static void mBN_set_character_dl(Submenu* submenu, GAME* game, mSM_MenuInfo_c* menu) {
+  static u8 kingaku_str[] = { CHAR_Y, CHAR_o, CHAR_u, CHAR_r, CHAR_SPACE, CHAR_A, CHAR_c, CHAR_c, CHAR_o, CHAR_u, CHAR_n, CHAR_t };
+  static u8 end_str[] = { CHAR_O, CHAR_K };
+  static rgba_t normal_col = { 0, 50, 255, 255 };
+  static rgba_t select_col = { 195, 20, 20, 255 };
+  static rgba_t bank_bell_col = { 170, 60, 145, 255 };
+  static rgba_t now_bell_col = { 115, 50, 215, 255 };
+  
+  mBN_Overlay_c* bank_ovl;
+  int cursol;
+  f32 width;
+  f32 digit_x;
+  int i;
+  u8 str[7];
+  f32 pos_x = menu->position[0];
+  f32 pos_y = menu->position[1];
+
+  bank_ovl = submenu->overlay->bank_ovl;
+
+  (*submenu->overlay->set_char_matrix_proc)(game->graph);
+  mFont_SetLineStrings(
+    game,
+    kingaku_str, sizeof(kingaku_str),
+    145.0f + pos_x, 65.0f - pos_y,
+    255, 255, 255, 255,
+    FALSE, TRUE,
+    0.875f, 0.875f,
+    mFont_MODE_POLY
+  );
+
+  mBN_set_num_str(211.0f + pos_x, 157.0f - pos_y, game, bank_ovl->bank_bell, 0.875f, &bank_bell_col);
+  mBN_set_num_str(211.0f + pos_x, 98.0f - pos_y, game, bank_ovl->now_bell, 0.875f, &now_bell_col);
+
+  cursol = bank_ovl->cursol;
+
+  if (cursol >= 3) {
+    cursol++;
+  }
+
+  mFont_UnintToString(str, 7, bank_ovl->bell, 6, FALSE, TRUE, TRUE);
+  width = mFont_GetStringWidth(str, 7, TRUE);
+
+  /* Draw each digit one by one */
+  digit_x = 211.0f + (pos_x - width);
+  for (i = 0; i < 7; i++) {
+    rgba_t* color = cursol == i ? &select_col : &normal_col;
+
+    mFont_SetLineStrings(
+      game,
+      str + i, 1,
+      digit_x, 124.0f - pos_y,
+      color->r, color->g, color->b, 255,
+      FALSE, TRUE,
+      1.0f, 1.0f,
+      mFont_MODE_POLY
+    );
+
+    width = mFont_GetStringWidth(str + i, 1, TRUE);
+    digit_x += width;
+  }
+
+  {
+    rgba_t* color = bank_ovl->cursol < mBN_CUSROL_OK ? &normal_col : &select_col;
+
+    mFont_SetLineStrings(
+      game,
+      end_str, sizeof(end_str),
+      208.0f + pos_x, 140.0f - pos_y,
+      color->r, color->g, color->b, 255,
+      FALSE, TRUE,
+      0.875f, 0.875f,
+      mFont_MODE_POLY
+    );
+  }
+}
+
+static void mBN_bank_ovl_draw(Submenu* submenu, GAME* game) {
+  mSM_MenuInfo_c* menu = &submenu->overlay->menu_info[mSM_OVL_BANK];
+  
+  (*menu->pre_draw_func)(submenu, game);
+  mBN_set_frame_dl(submenu, game, menu);
+  mBN_set_character_dl(submenu, game, menu);
+}
+
+extern void mBN_bank_ovl_set_proc(Submenu* submenu) {
+  Submenu_Overlay_c* overlay = submenu->overlay;
+
+  overlay->menu_control.menu_move_func = &mBN_bank_ovl_move;
+  overlay->menu_control.menu_draw_func = &mBN_bank_ovl_draw;
+}
+
+static void mBN_bank_ovl_init(Submenu* submenu) {
+  Submenu_Overlay_c* overlay = submenu->overlay;
+  mBN_Overlay_c* bank_ovl = overlay->bank_ovl;
+  int i;
+
+  overlay->menu_control.animation_flag = FALSE;
+  overlay->menu_info[mSM_OVL_BANK].proc_status = 0;
+  overlay->menu_info[mSM_OVL_BANK].next_proc_status = 1;
+  overlay->menu_info[mSM_OVL_BANK].move_drt = 5;
+
+  bank_ovl->now_bell = Common_Get(now_private)->inventory.wallet;
+  bank_ovl->now_bell += mBN_total_item_bell();
+  bank_ovl->player_bell = bank_ovl->now_bell;
+
+  mBN_now_bell_2_bell(bank_ovl);
+  bank_ovl->player_max_bell = mPr_WALLET_MAX;
+
+  for (i = 0; i < MONEY_NUM; i++) {
+    int sack_sum = mPr_GetPossessionItemSumWithCond(Common_Get(now_private), aNSM_itemNo[i], mPr_ITEM_COND_NORMAL);
+    
+    bank_ovl->player_max_bell += sack_sum * aNSM_sack_amount[3];
+  }
+
+  {
+    int sack_sum = mPr_GetPossessionItemSumWithCond(Common_Get(now_private), EMPTY_NO, mPr_ITEM_COND_NORMAL);
+    
+    bank_ovl->player_max_bell += sack_sum * aNSM_sack_amount[3];
+  }
+  bank_ovl->bank_bell = Common_Get(now_private)->bank_account;
+  bank_ovl->cursol = 0;
+}
+
+static mBN_Overlay_c bn_ovl_data;
+
+extern void mBN_bank_ovl_construct(Submenu* submenu) {
+  Submenu_Overlay_c* overlay = submenu->overlay;
+
+  if (overlay->bank_ovl == NULL) {
+    mem_clear((u8*)&bn_ovl_data, sizeof(mBN_Overlay_c), 0);
+    overlay->bank_ovl = &bn_ovl_data;
+  }
+
+  mBN_bank_ovl_init(submenu);
+  mBN_bank_ovl_set_proc(submenu);
+}
+
+extern void mBN_bank_ovl_destruct(Submenu* submenu) {
+  submenu->overlay->bank_ovl = NULL;
+}

--- a/rel/m_time.c
+++ b/rel/m_time.c
@@ -45,6 +45,11 @@
 static int debug_disp;
 static u8 l_renew_is;
 
+BSS_ORDER_GROUP_START
+  BSS_ORDER_ITEM(debug_disp)
+  BSS_ORDER_ITEM(l_renew_is)
+BSS_ORDER_GROUP_END
+
 const lbRTC_time_c mTM_rtcTime_clear_code = {
   0xFF, 0xFF, 0xFF,
   0xFF, 0xFF, 0xFF,
@@ -259,7 +264,7 @@ extern void mTM_set_renew_time(lbRTC_ymd_t* renew_time, const lbRTC_time_c* time
  * @param time Pointer to the lbRTC_time_c struct where the converted time will be stored.
  * @param ymd Pointer to the lbRTC_ymd_t struct containing the date to be converted.
  */
-extern void mTM_ymd_2_time(lbRTC_time_c* time, const lbRTC_ymd_t* ymd) {
+extern void mTM_ymd_2_time(lbRTC_time_c* time, lbRTC_ymd_t* ymd) {
   time->year = ymd->year;
   time->month = ymd->month;
   time->day = ymd->day;

--- a/rel/sys_matrix.c
+++ b/rel/sys_matrix.c
@@ -6,10 +6,6 @@
 #include "MSL_C/w_math.h"
 #include "libforest/gbi_extensions.h"
 
-MtxF* Matrix_now;
-MtxF* Matrix_stack;
-
-
 Mtx Mtx_clear = gdSPDefMtx(
     1.0f, 0.0f, 0.0f, 0.0f,
     0.0f, 1.0f, 0.0f, 0.0f,
@@ -24,6 +20,13 @@ MtxF MtxF_clear = { {
     {0.0f, 0.0f, 0.0f, 1.0f},
 } };
 
+static MtxF* Matrix_now;
+static MtxF* Matrix_stack;
+
+BSS_ORDER_GROUP_START
+    BSS_ORDER_ITEM(Matrix_stack)
+    BSS_ORDER_ITEM(Matrix_now)
+BSS_ORDER_GROUP_END
 
 void new_Matrix(GAME* game){
    Matrix_now =  THA_alloc16(&game->tha, 0x500);


### PR DESCRIPTION
* Added the newly created mwcceppc.exe 1.3.2r patch which disables pooling for const data types. This fixes all issues with pooling and removes the need for `-pool off` and `#pragma pool_data on`.
* Implemented & linked `m_bank_ovl.c`.
* Linked `m_time.c`.
* Minor changes required to `sys_matrix.c`.
* Update README.