### PR TITLE
Remove redundant parameter from suggested Docker command

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -48,5 +48,5 @@ ENV PATH="/ac-decomp/tools:${PATH}"
 ENV N64_SDK="/N64_SDK"
 ENV DEVKITPPC="/opt/devkitpro/devkitPPC"
 
-CMD echo 'Usage: docker run -it --rm -v ${PWD}:/ac-decomp ac-decomp python3 configure.py && ninja\n'\
+CMD echo 'Usage: docker run --rm -v ${PWD}:/ac-decomp ac-decomp python3 configure.py && ninja\n'\
          'See https://github.com/Prakxo/ac-decomp/blob/master/README.MD for more information'

--- a/README.MD
+++ b/README.MD
@@ -22,8 +22,8 @@ Use `--recursive` when cloning to have ppcdis in the repository.
 5. Download the [CodeWarrior 1.3.2r compiler](https://mega.nz/file/WuBFTCLT#TmB5R4-1mEFkk4G1Vjn9_cHXRD9wOIH9CtOLaVSWEas) and extract it to *tools/1.3.2r/*.
 6. Install Docker.
 7. Build the Docker image (`docker build -t ac-decomp .`).
-8. Run configure.py (`docker run -it --rm -v ${PWD}:/ac-decomp ac-decomp python3 configure.py`).
-9. Run ninja (`docker run -it --rm -v ${PWD}:/ac-decomp ac-decomp ninja`).
+8. Run configure.py (`docker run --rm -v ${PWD}:/ac-decomp ac-decomp python3 configure.py`).
+9. Run ninja (`docker run --rm -v ${PWD}:/ac-decomp ac-decomp ninja`).
 
 ### Build manually
 


### PR DESCRIPTION
As it turns out, you don't need `-it` to output Docker to your terminal. Sorry I didn't catch this before my last pull got merged.