### PR TITLE
Move decompression logic to configure.py

### DIFF
--- a/build.py
+++ b/build.py
@@ -93,11 +93,6 @@ if __name__ == "__main__":
             else:
                 print(f"No changes in {target[0]}, skipping build.")
         try:
-            # Check if foresta.rel.szs exists but not foresta.rel, and if so, decompress
-            if not os.path.exists(c.REL) and os.path.exists(c.REL_SZS):
-                print("Decompressing foresta.rel.szs to foresta.rel")
-                subprocess.call([f'./{c.ORTHRUS}', 'ncompress', 'yaz0', '-d', c.REL_SZS, c.REL])
-
             if args.v:
                 subprocess.run(['ninja', '-v'], check=True)
             else:

--- a/configure.py
+++ b/configure.py
@@ -9,6 +9,7 @@ import json
 import os
 import pickle
 import re
+import subprocess
 from io import StringIO
 
 from sys import executable as PYTHON, platform
@@ -29,6 +30,11 @@ if os.path.exists("dump/main.dol"):
 assert os.path.exists("tools/1.3.2/mwcceppc.exe") and \
     os.path.exists("tools/1.2.5n/mwcceppc.exe"), \
        "Error: Codewarrior not found!"
+
+# Check if foresta.rel.szs exists but not foresta.rel, and if so, decompress
+if not os.path.exists(c.REL) and os.path.exists(c.REL_SZS):
+    print("Decompressing foresta.rel.szs to foresta.rel")
+    subprocess.call([f'./{c.ORTHRUS}', 'ncompress', 'yaz0', '-d', c.REL_SZS, c.REL])
 
 # Check binaries were added
 assert os.path.exists(c.DOL) and os.path.exists(c.REL), \


### PR DESCRIPTION
Before, foresta.rel.szs would not decompress before the configuration binary check ran. This caused an assert to trigger.