### PR TITLE
Use buildx instead of legacy builder

### DIFF
--- a/docker-setup.bat
+++ b/docker-setup.bat
@@ -8,7 +8,7 @@ IF exist tools\1.3.2r\ ( echo 1.3.2r exists ) ELSE ( goto compilers )
 goto buildimage
 
 :buildimage
-docker build -t ac-decomp .
+docker buildx build -t ac-decomp .
 echo "Docker image setup is now complete. You may proceed with the instructions."
 pause
 exit

--- a/docker-setup.sh
+++ b/docker-setup.sh
@@ -27,5 +27,5 @@ if [ ! -d "tools/1.2.5n" ]; then mv compilers_temp/GC/1.2.5n/ tools/; fi
 if [ ! -d "tools/1.3.2" ]; then mv compilers_temp/GC/1.3.2/ tools/; fi
 if [ ! -d "tools/1.3.2r" ]; then mv compilers_temp/GC/1.3.2r/ tools/; fi
 rm -r compilers_temp compilers_latest.zip
-docker build -t ac-decomp .
+docker buildx build -t ac-decomp .
 echo "Docker image setup is now complete. You may proceed with the instructions."


### PR DESCRIPTION
Closes #434 

Works same as it did with the legacy builder. No major changes were required.